### PR TITLE
Make tags variable and include missing tags

### DIFF
--- a/terraform/modules/infra-ecs-fargate/main.tf
+++ b/terraform/modules/infra-ecs-fargate/main.tf
@@ -22,9 +22,7 @@ module "ecs" {
     }
   ]
 
-  tags = {
-    owning_team = "CAOS"
-  }
+  tags = var.tags
 }
 
 #########################################
@@ -36,6 +34,8 @@ module "cloudwatch_log-group" {
 
   name              = var.cloudwatch_log_group
   retention_in_days = 14
+
+  tags = var.tags
 }
 
 
@@ -68,9 +68,7 @@ module "iam_policy_fargate" {
 }
 EOF
 
-  tags = {
-    owning_team = "CAOS"
-  }
+  tags = var.tags
 }
 
 
@@ -88,6 +86,8 @@ module "iam_assumable_role_custom" {
   custom_role_policy_arns = [
     module.iam_policy_fargate.arn
   ]
+
+  tags = var.tags
 }
 
 data "aws_iam_policy_document" "custom_trust_policy" {
@@ -156,6 +156,8 @@ module "ecs-fargate-task-definition" {
       "awslogs-stream-prefix" : var.cloudwatch_log_prefix
     }
   }
+
+  tags = var.tags
 }
 
 
@@ -174,6 +176,8 @@ module "efs" {
   create_security_group          = true
   allowed_security_group_ids     = [var.canaries_security_group]
   additional_security_group_rules = var.additional_efs_security_group_rules
+
+  tags = var.tags
 }
 
 
@@ -218,9 +222,7 @@ module "iam_policy_task_execution" {
 }
 EOF
 
-  tags = {
-    owning_team = "CAOS"
-  }
+  tags = var.tags
 }
 
 #########################################
@@ -244,7 +246,5 @@ module "iam_iam-assumable-role-with-oidc" {
   role_policy_arns      = [
     module.iam_policy_task_execution.arn
   ]
-  tags = {
-    "owning_team" : "CAOS"
-  }
+  tags = var.tags
 }

--- a/terraform/modules/infra-ecs-fargate/variables.tf
+++ b/terraform/modules/infra-ecs-fargate/variables.tf
@@ -107,6 +107,12 @@ variable "cloudwatch_log_prefix" {
   type        = string
 }
 
+variable "tags" {
+  default = {
+    owning_team = "CAOS"
+  }
+}
+
 variable "task_container_cpu" {
   default = "4096"
 }

--- a/terraform/modules/infra-ecs-fargate/variables.tf
+++ b/terraform/modules/infra-ecs-fargate/variables.tf
@@ -108,6 +108,7 @@ variable "cloudwatch_log_prefix" {
 }
 
 variable "tags" {
+  type = map
   default = {
     owning_team = "CAOS"
   }


### PR DESCRIPTION
This PR makes the "tags" argument included in the created AWS resources variable with a default value that equals to its current value. This ensures backwards compatibility: callers of this module that were using the previous version will be able to use it with the same arguments.

Also, this PR includes the "tags" to some AWS modules that were being instantiated without it. This way, all created resources will be properly tagged.