### PR TITLE
Allow providing a IAM permissions boundary policy

### DIFF
--- a/terraform/modules/infra-ecs-fargate/main.tf
+++ b/terraform/modules/infra-ecs-fargate/main.tf
@@ -87,6 +87,8 @@ module "iam_assumable_role_custom" {
     module.iam_policy_fargate.arn
   ]
 
+  role_permissions_boundary_arn = var.iam_permissions_boundary_policy_arn
+
   tags = var.tags
 }
 
@@ -243,6 +245,7 @@ module "iam_iam-assumable-role-with-oidc" {
   force_detach_policies = true
   max_session_duration  = 43200
   aws_account_id        = var.account_id
+  role_permissions_boundary_arn = var.iam_permissions_boundary_policy_arn
   role_policy_arns      = [
     module.iam_policy_task_execution.arn
   ]

--- a/terraform/modules/infra-ecs-fargate/variables.tf
+++ b/terraform/modules/infra-ecs-fargate/variables.tf
@@ -125,3 +125,9 @@ variable "task_container_memory" {
 variable "task_container_memory_reservation" {
   default = "2048"
 }
+
+variable "iam_permissions_boundary_policy_arn" {
+  default = ""
+  description = "A policy boundary to limit the permissions granted to the IAM roles created by this module"
+  type = string
+}


### PR DESCRIPTION
Allow providing an IAM permissions boundary policy to restrict the permissions granted to the IAM roles created in the module.