### PR TITLE
Add permissions boundary to the ECS task execution role that gets created

### DIFF
--- a/terraform/modules/infra-ecs-fargate/main.tf
+++ b/terraform/modules/infra-ecs-fargate/main.tf
@@ -146,6 +146,7 @@ module "ecs-fargate-task-definition" {
   task_role_arn                           = module.iam_assumable_role_custom.iam_role_arn
 
   ecs_task_execution_role_custom_policies = var.task_custom_policies
+  permissions_boundary                    = var.iam_permissions_boundary_policy_arn
 
   secrets = var.task_secrets
 


### PR DESCRIPTION
This is a follow up of the previous PR. I missed that in the `ecs-fargate-task-definition`, an IAM role gets created under the hood. This module has a [permissions_boundary argument](https://registry.terraform.io/modules/cn-terraform/ecs-fargate-task-definition/aws/latest?tab=inputs#:~:text=permissions_boundary) that allows passing the permissions boundary policy arn as well.

In this module, the default for it is `null`, as opposed to the other modules already being used from cloudposse that default to an empty string `""`. But I verified that under the hood, both just pass the arn string to the aws_iam_role resource ([cloudposse](https://github.com/terraform-aws-modules/terraform-aws-iam/blob/v5.21.0/modules/iam-assumable-role-with-oidc/main.tf#L97), [cn-terraform](https://github.com/cn-terraform/terraform-aws-ecs-fargate-task-definition/blob/main/main.tf#L8)). So, both work. The only difference would be that for an existing IAM role, passing an empty string means removing any existing permissions boundary to the role, while passing a `null` would be to not modify the existing role boundary.

Since the prior version of `fargate-runner-action` was not passing any argument for them, any existing role will not have any boundary anyway. So, it is safe to just default to an empty string now.