### PR TITLE
Update ecs-fargate-task-definition to solve bug that prevents passing ARN references

### DIFF
--- a/terraform/modules/infra-ecs-fargate/main.tf
+++ b/terraform/modules/infra-ecs-fargate/main.tf
@@ -110,7 +110,7 @@ data "aws_iam_policy_document" "custom_trust_policy" {
 #########################################
 module "ecs-fargate-task-definition" {
   source  = "registry.terraform.io/cn-terraform/ecs-fargate-task-definition/aws"
-  version = "1.0.29"
+  version = "1.0.35"
 
   container_image              = var.task_container_image
   container_name               = var.task_container_name


### PR DESCRIPTION
This PR updates the ecs-fargate-task-definition version in order to include this fix: https://github.com/cn-terraform/terraform-aws-ecs-fargate-task-definition/pull/30. The fix was introduced in 1.0.30, but I chose to update to the latest patch version. Specifically, this will allow us to pass task custom policies like this:

```
resource "aws_secretsmanager_secret" "foo" {
  name = "bar"
}

...

task_custom_policies = [
    jsonencode(
      {
        "Version" : "2012-10-17",
        "Statement" : [
          {
            "Effect" : "Allow",
            "Action" : [
              "secretsmanager:GetSecretValue"
            ],
            "Resource" : [
              aws_secretsmanager_secret.foo.arn
            ]
          }
        ]
      }
    )
```