### PR TITLE
Allow passing specific rights for the Fargate task runtime

### DIFF
--- a/terraform/modules/infra-ecs-fargate/variables.tf
+++ b/terraform/modules/infra-ecs-fargate/variables.tf
@@ -51,7 +51,7 @@ variable "task_name_prefix" {
 }
 
 variable "task_custom_policies" {
-  description = "Task custom policies json"
+  description = "Task *execution (launching)* custom policies json. The rights provided here will be added to the role *launching* the Fargate task. Note that these rights allow, for instance, reading an AWS Secret that is passed to the task as an environment variable (through the task_secrets variable) when *launching* it. These rights are different from the ones the processes running inside of the Fargate task have. For instance, if the task needs to launch some EC2 instances, you'd need to give it ec2:* rights through the task_runtime_custom_policies variable."
   type    = list(string)
   default = []
 }
@@ -63,6 +63,12 @@ variable "task_secrets" {
     valueFrom = string
   }))
   default = []
+}
+
+variable "task_runtime_custom_policies" {
+  description = "Task *runtime* custom policies json. The rights provided here will be available to the processes running inside of the launched Fargate task. For instance, if the task needs to launch some EC2 instances, you'd need to give it the required ec2:* rights through this variable. The task is always given the minimum permissions to access the Terraform S3 state bucket. If this variable is not provided, ec2:* rights will be given to guarantee the backwards compatibility of this module. Ideally, users of this module should provide their minimum set of necessary rights for the task runtime via this variable."
+  type    = list(string)
+  default = null
 }
 
 variable "efs_volume_name" {


### PR DESCRIPTION
Right now, the Fargate task runtime gets the following rights by default:
- ec2:* on any resource
- s3:* on the Terraform S3 states bucket

The previous rights have a couple of problems. On the one hand, they are too broad. For instance, for Terraform to use the S3 bucket as its backend, only [these permissions](https://developer.hashicorp.com/terraform/language/settings/backends/s3#s3-bucket-permissions)are required. Also, being able to do _any_ action on _any_ EC2 instance is dangerous: a misconfigured make target could result in us accessing EC2 instances that we're probably not supposed to. On the other hand, the current permissions are focused on a single use case for this E2E testing infrastructure: executing E2E tests against EC2 instances that are accessed using SSH from the task.

We have been requested to not access the EC2 instances using SSH, but SSM.  As users of this E2E infrastructure, this requires us to grant the following extra rights to the Fargate task runtime:
- `ssm:StartSession`
- `ssm:TerminateSession`
- `iam:PassRole` to the `"ec2.amazonaws.com"` service --> because we [need to provide](https://repost.aws/knowledge-center/ec2-systems-manager-vpc-endpoints#:~:text=Create%20an%20AWS,private%20EC2%20instance.) an "instance profile" (that maps to a role) to the EC2 instance to allow executing several SSM-related actions so it can register itself against SSM.
- `s3:*` on a bucket used by SSM to transfer files back and forth the managed EC2 instance.

This is just an example. In the future, we envision spinning up Kubernetes clusters, install Helm charts in them and E2E testing them as well, which would require us to grant some `eks:*` permissions as well.

So, I believe that being able to provide the specific rights that the task runtime needs will be beneficial into making this module more general. Also, this allows the caller to fine-grain them (i.e. only allow accessing certain EC2 instances, for example).

I made the changes so that the current behavior doesn't change: if the new `task_runtime_custom_policies` is not provided, the current rights will be provided to the task runtime. I only allowed myself to do a little modification though: I made sure to only grant the minimum necessary rights over S3 that Terraform mentions in [its documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3#s3-bucket-permissions).