### PR TITLE
Allow passing non-secret environment variables to the containers

### DIFF
--- a/terraform/modules/infra-ecs-fargate/main.tf
+++ b/terraform/modules/infra-ecs-fargate/main.tf
@@ -177,6 +177,7 @@ module "ecs-fargate-task-definition" {
   ecs_task_execution_role_custom_policies = var.task_custom_policies
   permissions_boundary                    = var.iam_permissions_boundary_policy_arn
 
+  environment = var.task_environment
   secrets = var.task_secrets
 
   log_configuration = {

--- a/terraform/modules/infra-ecs-fargate/variables.tf
+++ b/terraform/modules/infra-ecs-fargate/variables.tf
@@ -45,6 +45,15 @@ variable "task_container_name" {
   type        = string
 }
 
+variable "task_environment" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  description = "The environment variables to pass to the container."
+  default     = []
+}
+
 variable "task_name_prefix" {
   description = "Task name prefix"
   type        = string


### PR DESCRIPTION
This allows passing environment variables down to the Fargate task containers without having to create secrets for them. This is useful for non-sensitive data such as the `NEW_RELIC_REGION` or `NEW_RELIC_ACCOUNT_ID`.